### PR TITLE
🔑 Make API key optional for server-side proxy support

### DIFF
--- a/modules/extensions/checks/EmailCheckExtension.js
+++ b/modules/extensions/checks/EmailCheckExtension.js
@@ -137,15 +137,21 @@ var EmailCheckExtension = {
 
                         // Send user data to remote server for validation.
                         ExtendableObject._awaits++;
+
+                        const headers = {
+                            'X-Agent': ExtendableObject.config.agentName,
+                            'X-Remote-Api-Url': ExtendableObject.config.remoteApiUrl,
+                            'X-Transaction-Referer': window.location.href,
+                            'X-Transaction-Id': (ExtendableObject.hasLoadedExtension('SessionExtension'))?ExtendableObject.sessionId:'not_required'
+                        };
+
+                        if (ExtendableObject.config.apiKey) {
+                            headers['X-Auth-Key'] = ExtendableObject.config.apiKey;
+                        }
+
                         ExtendableObject.util.axios.post(ExtendableObject.config.apiUrl, message, {
                             timeout: 6000,
-                            headers: {
-                                'X-Auth-Key': ExtendableObject.config.apiKey,
-                                'X-Agent': ExtendableObject.config.agentName,
-                                'X-Remote-Api-Url': ExtendableObject.config.remoteApiUrl,
-                                'X-Transaction-Referer': window.location.href,
-                                'X-Transaction-Id': (ExtendableObject.hasLoadedExtension('SessionExtension'))?ExtendableObject.sessionId:'not_required'
-                            }
+                            headers
                         })
                             .then(function(response) {
                                 if (undefined !== response.data.result) {

--- a/modules/extensions/checks/NameCheckExtension.js
+++ b/modules/extensions/checks/NameCheckExtension.js
@@ -286,15 +286,21 @@ var NameCheckExtension = {
 
                         // Send user data to remote server for validation.
                         ExtendableObject._awaits++;
+
+                        const headers = {
+                            'X-Agent': ExtendableObject.config.agentName,
+                            'X-Remote-Api-Url': ExtendableObject.config.remoteApiUrl,
+                            'X-Transaction-Referer': window.location.href,
+                            'X-Transaction-Id': (ExtendableObject.hasLoadedExtension('SessionExtension'))?ExtendableObject.sessionId:'not_required'
+                        };
+
+                        if (ExtendableObject.config.apiKey) {
+                            headers['X-Auth-Key'] = ExtendableObject.config.apiKey;
+                        }
+
                         ExtendableObject.util.axios.post(ExtendableObject.config.apiUrl, message, {
                             timeout: 2000,
-                            headers: {
-                                'X-Auth-Key': ExtendableObject.config.apiKey,
-                                'X-Agent': ExtendableObject.config.agentName,
-                                'X-Remote-Api-Url': ExtendableObject.config.remoteApiUrl,
-                                'X-Transaction-Referer': window.location.href,
-                                'X-Transaction-Id': (ExtendableObject.hasLoadedExtension('SessionExtension'))?ExtendableObject.sessionId:'not_required'
-                            }
+                            headers
                         })
                             .then(function(response) {
                                 if (undefined !== response.data.result) {

--- a/modules/extensions/checks/PhoneCheckExtension.js
+++ b/modules/extensions/checks/PhoneCheckExtension.js
@@ -188,15 +188,21 @@ var PhoneCheckExtension = {
 
                         // Send user data to remote server for validation.
                         ExtendableObject._awaits++;
+
+                        const headers = {
+                            'X-Agent': ExtendableObject.config.agentName,
+                            'X-Remote-Api-Url': ExtendableObject.config.remoteApiUrl,
+                            'X-Transaction-Referer': window.location.href,
+                            'X-Transaction-Id': (ExtendableObject.hasLoadedExtension('SessionExtension'))?ExtendableObject.sessionId:'not_required'
+                        };
+
+                        if (ExtendableObject.config.apiKey) {
+                            headers['X-Auth-Key'] = ExtendableObject.config.apiKey;
+                        }
+
                         ExtendableObject.util.axios.post(ExtendableObject.config.apiUrl, message, {
                             timeout: 6000,
-                            headers: {
-                                'X-Auth-Key': ExtendableObject.config.apiKey,
-                                'X-Agent': ExtendableObject.config.agentName,
-                                'X-Remote-Api-Url': ExtendableObject.config.remoteApiUrl,
-                                'X-Transaction-Referer': window.location.href,
-                                'X-Transaction-Id': (ExtendableObject.hasLoadedExtension('SessionExtension'))?ExtendableObject.sessionId:'not_required'
-                            }
+                            headers
                         })
                             .then(function(response) {
                                 if (undefined !== response.data.result) {

--- a/modules/extensions/fields/AddressExtension.js
+++ b/modules/extensions/fields/AddressExtension.js
@@ -2051,7 +2051,6 @@ const AddressExtension = {
             const cacheKey = generateAddressCacheKey(addressToCheck);
 
             const headers = {
-                'X-Auth-Key': ExtendableObject.config.apiKey,
                 'X-Agent': ExtendableObject.config.agentName,
                 'X-Remote-Api-Url': ExtendableObject.config.remoteApiUrl,
                 'X-Transaction-Referer': window.location.href,
@@ -2059,6 +2058,11 @@ const AddressExtension = {
                     ? ExtendableObject.sessionId
                     : 'not_required'
             };
+
+            // Only add API key if it's provided
+            if (ExtendableObject.config.apiKey) {
+                headers['X-Auth-Key'] = ExtendableObject.config.apiKey;
+            }
 
             if (!ExtendableObject.addressCheckCache.cachedResults[cacheKey]) {
                 try {


### PR DESCRIPTION
## Summary
This PR makes the API key optional in the Endereco JavaScript SDK, allowing systems to proxy requests through their own servers and add the API key server-side for enhanced security.

## Changes Made
- Modified API request headers to conditionally include the `X-Auth-Key` only when `apiKey` is configured
- Updated the following extensions:
  - `AddressExtension.js` - Modified `getAddressMeta` function
  - `EmailCheckExtension.js` - Modified `checkEmail` function  
  - `PhoneCheckExtension.js` - Modified `checkPhone` function
  - `NameCheckExtension.js` - Modified `checkPerson` function
- No breaking changes - maintains full backward compatibility

## Testing
- [ ] Manual testing in demo environment
- [ ] Integration testing completed
- [ ] No breaking changes to existing APIs

## Related Issues
This change enables server-side proxy patterns for systems that need to keep API keys secret and add them via backend proxy services.

This enhancement complements the server-side proxy implementation in the Shopware 6 plugin ([PR #76](https://github.com/Endereco/endereco-shopware6-client/pull/76)), where API keys are stored securely in the backend and requests are proxied through the shop's server. With this SDK change, the Shopware plugin and similar implementations can now operate without exposing API keys in the frontend.

## Implementation Details
When `config.apiKey` is not provided or is empty, the SDK will make requests without the `X-Auth-Key` header. This allows backend systems to:
1. Intercept the requests via a proxy
2. Add the API key server-side
3. Forward the request to Endereco's API

Existing implementations with client-side API keys will continue to work exactly as before.