### PR TITLE
Strengthen subdivisionCode validation to prevent undefined and empty string errors

### DIFF
--- a/modules/extensions/fields/AddressExtension.js
+++ b/modules/extensions/fields/AddressExtension.js
@@ -1885,7 +1885,11 @@ const AddressExtension = {
                 preparedData.countryName = address.countryCode.toUpperCase();
             }
 
-            if (Object.prototype.hasOwnProperty.call(address, 'subdivisionCode')) {
+            if (
+                Object.prototype.hasOwnProperty.call(address, 'subdivisionCode') &&
+                typeof address.subdivisionCode === 'string' &&
+                address.subdivisionCode.trim().length > 0
+            ) {
                 if (Boolean(window.EnderecoIntegrator.subdivisionCodeToNameMapping) &&
                     Boolean(window.EnderecoIntegrator.subdivisionCodeToNameMapping[address.subdivisionCode.toUpperCase()])
                 ) {


### PR DESCRIPTION
## Summary
Strengthen subdivisionCode validation to prevent undefined and empty string errors

## Changes Made
- Added string validation for subdivisionCode: typeof address.subdivisionCode === 'string'
- Added length validation for subdivisionCode: address.subdivisionCode.trim().length > 0

## Testing
- [x] Manual testing in demo environment
- [x] Cross-browser compatibility verified
- [x] Integration testing completed
- [x] No breaking changes to existing APIs

## Related Issues
https://github.com/Endereco/js-sdk/issues/21

Ref: DEV-216