### PR TITLE
Fix "ESC key doesn’t work in popup as expected"

### DIFF
--- a/modules/extensions/fields/LocalityExtension.js
+++ b/modules/extensions/fields/LocalityExtension.js
@@ -277,6 +277,10 @@ const LocalityExtension = {
                     ExtendableObject._localityPredictionsIndex = ExtendableObject._localityPredictions.length - 1;
                     ExtendableObject.util.renderLocalityPredictionsDropdown();
                 } else if (e.key === 'Escape') {
+                    if(ExtendableObject._localityPredictions.length) {
+                        e.preventDefault();
+                        e.stopPropagation(); 
+                    }
                     ExtendableObject.resetLocalityPredictions();
                     ExtendableObject.util.removeLocalityPredictionsDropdown();
                 } else if (e.key === 'Tab') {

--- a/modules/extensions/fields/PostalCodeExtension.js
+++ b/modules/extensions/fields/PostalCodeExtension.js
@@ -280,6 +280,10 @@ const PostalCodeExtension = {
                     ExtendableObject._postalCodePredictionsIndex = ExtendableObject._postalCodePredictions.length - 1;
                     ExtendableObject.util.renderPostalCodePredictionsDropdown();
                 } else if (e.key === 'Escape') {
+                    if(ExtendableObject._postalCodePredictions.length) {
+                        e.preventDefault();
+                        e.stopPropagation(); 
+                    }
                     ExtendableObject.resetPostalCodePredictions();
                     ExtendableObject.util.removePostalCodePredictionsDropdown();
                 } else if (e.key === 'Tab') {

--- a/modules/extensions/fields/StreetFullExtension.js
+++ b/modules/extensions/fields/StreetFullExtension.js
@@ -273,6 +273,10 @@ const StreetFullExtension = {
                         ExtendableObject.streetFullPredictions
                     );
                 } else if (e.key === 'Escape') {
+                    if(ExtendableObject._streetFullPredictions.length) {
+                        e.preventDefault();
+                        e.stopPropagation(); 
+                    } 
                     ExtendableObject.resetStreetFullPredictions();
                     ExtendableObject.util.removeStreetFullPredictionsDropdown();
                 } else if (e.key === 'Tab') {

--- a/modules/extensions/fields/StreetNameExtension.js
+++ b/modules/extensions/fields/StreetNameExtension.js
@@ -280,6 +280,10 @@ const StreetNameExtension = {
                         ExtendableObject.streetNamePredictions
                     );
                 } else if (e.key === 'Escape') {
+                    if(ExtendableObject._streetNamePredictions.length) {
+                        e.preventDefault();
+                        e.stopPropagation(); 
+                    }
                     ExtendableObject.resetStreetNamePredictions();
                     ExtendableObject.util.removeStreetNamePredictionsDropdown();
                 } else if (e.key === 'Tab') {


### PR DESCRIPTION
Why the problem appears:
- Problem exists only with modals.
- Shopware/bootstrap closes modal on "escape" keypress.
- JS-SDK handles "escape" but does not stop bubbling, so modal closes.

Solution:
- Added ESC-keydown handling for Postcode/City/Street/StreetName fields.
- If autocomplete suggestions exist: clear them and stop default.
- If no suggestions: fallback to default behaviour (modal closes).

Ref: DEV-229