### PR TITLE
Add missing status reset on cleared inputs and optimize and adapt name validation logic

### DIFF
--- a/demo/use-cases/example/index.html
+++ b/demo/use-cases/example/index.html
@@ -151,6 +151,7 @@
 			window.EnderecoIntegrator.config.ux.showPhoneFlag = true;
             window.EnderecoIntegrator.countryMappingUrl = '';
 			window.EnderecoIntegrator.config.useAutocomplete = true;
+			window.EnderecoIntegrator.config.ux.correctTranspositionedNames = true;
             window.EnderecoIntegrator.config.templates.primaryButtonClasses = 'btn btn-primary btn-lg';
             window.EnderecoIntegrator.config.templates.secondaryButtonClasses = 'btn btn-secondary btn-lg';
             window.EnderecoIntegrator.config.texts = {
@@ -478,6 +479,7 @@
 				<label class="label">
 					Anrede
 					<select name="salutation1">
+						<option value="x">Bitte auswählen</option>
 						<option value="m">Herr</option>
 						<option value="f">Frau</option>
 					</select>
@@ -522,6 +524,7 @@
 				<label class="label">
 					Anrede
 					<select name="salutation2">
+						<option value="x">Bitte auswählen</option>
 						<option value="m">Herr</option>
 						<option value="f">Frau</option>
 					</select>

--- a/modules/extensions/checks/NameCheckExtension.js
+++ b/modules/extensions/checks/NameCheckExtension.js
@@ -17,6 +17,7 @@ var NameCheckExtension = {
                 ExtendableObject._subscribers.titleStatus = [];
                 ExtendableObject._subscribers.nameScore = [];
                 ExtendableObject._nameCheckRequestIndex = 1;
+                ExtendableObject._nameCorrected = false;
 
                 // Add change event hadler.
                 ExtendableObject.cb.salutationStatusChange = function(subscriber) {
@@ -316,54 +317,43 @@ var NameCheckExtension = {
                                         ExtendableObject.firstNameStatus = [];
                                         ExtendableObject.lastNameStatus = [];
 
-                                        if (!['m', 'f', 'd'].includes(ExtendableObject.salutation) && !!responsePredictions[0].salutation) {
-                                            ExtendableObject.salutation = responsePredictions[0].salutation;
-                                            salutationCopied = true;
-                                        }
+                                        // Execute auto-correct on name fields and set salutation and title exactly once
+                                        // across all requests, regardless of the current request index.
+                                        if (!ExtendableObject._nameCorrected) {
+                                            if (!['m', 'f', 'd'].includes(ExtendableObject.salutation) && !!responsePredictions[0].salutation) {
+                                                ExtendableObject.salutation = responsePredictions[0].salutation;
+                                                salutationCopied = true;
+                                            }
 
-                                        if (1 === ExtendableObject._nameCheckRequestIndex) {
-                                            if (!responseStatus.includes('name_transpositioned')) {
+                                            if (ExtendableObject.isTitleRelevant()) {
+                                                ExtendableObject.title = responsePredictions[0].title;
+
+                                                if (responsePredictions[0].title !== '') {
+                                                    ExtendableObject.titleStatus = ['title_correct'];
+                                                }
+                                            }
+
+                                            if (responseStatus.includes('name_transpositioned')) {
+                                                if (ExtendableObject.config.ux.correctTranspositionedNames) {
+                                                    ExtendableObject.firstName = responsePredictions[0].firstName;
+                                                    ExtendableObject.lastName = responsePredictions[0].lastName;
+                                                } else {
+                                                    ExtendableObject.firstName = responsePredictions[0].lastName;
+                                                    ExtendableObject.lastName = responsePredictions[0].firstName;
+                                                }
+                                            } else {
                                                 ExtendableObject.firstName = responsePredictions[0].firstName;
                                                 ExtendableObject.lastName = responsePredictions[0].lastName;
-
-
-                                                ExtendableObject.firstNameStatus = ['first_name_correct'];
-                                                ExtendableObject.lastNameStatus = ['last_name_correct'];
-
-                                                if (ExtendableObject.isTitleRelevant()) {
-                                                    ExtendableObject.title = responsePredictions[0].title;
-
-                                                    if (responsePredictions[0].title !== '') {
-                                                        ExtendableObject.titleStatus = ['title_correct'];
-                                                    }
-                                                }
-
-
-                                            } else if (responseStatus.includes('name_transpositioned')) {
-                                                if (ExtendableObject.config.ux.correctTranspositionedNames) {
-                                                    ExtendableObject.lastName = responsePredictions[0].lastName;
-                                                    ExtendableObject.firstName = responsePredictions[0].firstName;
-                                                } else {
-                                                    ExtendableObject.lastName = responsePredictions[0].firstName;
-                                                    ExtendableObject.firstName = responsePredictions[0].lastName;
-                                                }
-
-                                                if (ExtendableObject.isTitleRelevant()) {
-                                                    ExtendableObject.title = responsePredictions[0].title;
-
-                                                    if (responsePredictions[0].title !== '') {
-                                                        ExtendableObject.titleStatus = ['title_correct'];
-                                                    }
-                                                }
-
-                                                ExtendableObject.firstNameStatus = ['first_name_correct'];
-                                                ExtendableObject.lastNameStatus = ['last_name_correct'];
                                             }
+                                            ExtendableObject.firstNameStatus = ['first_name_correct'];
+                                            ExtendableObject.lastNameStatus = ['last_name_correct'];
+                                            ExtendableObject._nameCorrected = true;
                                         }
 
                                         if (responseStatus.includes('name_correct')) {
-                                            ExtendableObject.firstNameStatus = ['first_name_correct'];
-                                            ExtendableObject.lastNameStatus = ['last_name_correct'];
+                                            ExtendableObject.firstNameStatus = ExtendableObject.firstName.trim()? ['first_name_correct'] : [];
+                                            ExtendableObject.lastNameStatus = ExtendableObject.lastName.trim()? ['last_name_correct'] : [];
+
                                             if (ExtendableObject.isTitleRelevant() && ExtendableObject.title !== '') {
                                                 ExtendableObject.titleStatus = ['title_correct'];
                                             }
@@ -373,13 +363,17 @@ var NameCheckExtension = {
 
                                         // Set statuscodes.
                                         if (salutationCopied) {
-                                            ExtendableObject.salutationStatus = ['salutation_correct'];
+                                            if (responsePredictions[0].salutation === 'x') {
+                                                ExtendableObject.salutationStatus = [];
+                                            } else {
+                                                ExtendableObject.salutationStatus = ['salutation_correct'];
+                                            }
                                         } else {
-                                            if (!responsePredictions[0].salutation) {
+                                            if (!responsePredictions[0].salutation || responsePredictions[0].salutation === 'x') {
                                                 ExtendableObject.salutationStatus = [];
                                             } else {
                                                 ExtendableObject.salutationStatus =
-                                                  (responseStatus.includes('salutation_needs_correction'))?['salutation_needs_correction']:['salutation_correct'];
+                                                    (responseStatus.includes('salutation_needs_correction')) ? ['salutation_needs_correction'] : ['salutation_correct'];
                                             }
                                         }
 

--- a/modules/extensions/fields/FirstNameExtension.js
+++ b/modules/extensions/fields/FirstNameExtension.js
@@ -46,6 +46,10 @@ var FirstNameExtension = {
                             ExtendableObject._firstName = newValue;
                             ExtendableObject._changed = true;
 
+                            if ('' === newValue.trim()) {
+                                ExtendableObject.firstNameStatus = [];  
+                            }
+                            
                             // Inform all subscribers about the change.
                             ExtendableObject._subscribers.firstName.forEach(function (subscriber) {
                                 subscriber.value = value;

--- a/modules/extensions/fields/LastNameExtension.js
+++ b/modules/extensions/fields/LastNameExtension.js
@@ -47,6 +47,10 @@ var LastNameExtension = {
                             ExtendableObject._lastName = newValue;
                             ExtendableObject._changed = true;
 
+                            if ('' === newValue.trim()) {
+                                ExtendableObject.lastNameStatus = [];  
+                            }
+
                             // Inform all subscribers about the change.
                             ExtendableObject._subscribers.lastName.forEach(function (subscriber) {
                                 subscriber.value = value;

--- a/modules/extensions/fields/PhoneExtension.js
+++ b/modules/extensions/fields/PhoneExtension.js
@@ -117,6 +117,10 @@ var PhoneExtension = {
                                 ExtendableObject._phone = newValue;
                                 ExtendableObject._changed = true;
 
+                                if ('' === newValue.trim()) {
+                                    ExtendableObject.phoneStatus = [];  
+                                }
+
                                 // Inform all subscribers about the change.
                                 ExtendableObject._subscribers.phone.forEach(function (subscriber) {
                                     subscriber.value = newValue;

--- a/modules/extensions/fields/TitleExtension.js
+++ b/modules/extensions/fields/TitleExtension.js
@@ -46,6 +46,10 @@ var TitleExtension = {
                             ExtendableObject._title = newValue;
                             ExtendableObject._changed = true;
 
+                            if ('' === newValue.trim()) {
+                                ExtendableObject.titleStatus = [];  
+                            }
+
                             // Inform all subscribers about the change.
                             ExtendableObject._subscribers.title.forEach(function (subscriber) {
                                 subscriber.value = value;


### PR DESCRIPTION
**Add status reset on cleared input in Phone, Title and Name Extensions**

On clearing the title,phone, firstName or lastName  field, the validation status was
not reset . This could result in empty fields showing a validation status.
This commit adds status reset, when the value in the respective input fields
is changed to an empty string. Title-, phone- and name fields now behave consistently
with the email- and addressfields.

Ref: DEV-343/bugs 1 and 6

**Optimize and adapt name validation logic**

The name validation logic in NameCheckExtension.js had a few issues;

DEV-343/2: When the first request returned "name_not_found", for example
when there was a typo in the name, on the second request with API answer
"name_needs_correction" the field status for firstName and lastName was not
set. The reason was, that firstNameStatus and lastNameStatus where only
set on the request with index 1.
This commit replaces the request index in the respective if-clause with a persistent
boolean flag nameCorrected. This ensures, that firstNameStatus and lastNameStatus
will be set on the first request that returns "name_needs_correction" and, as it
was before, on every request that returns "name_correct".

DEV-343/3: On requests with response "salutation x", the salutation field status
was set to "salutation_correct". This resulted in salutation fields with value
"Bitte wählen" or "keine Angabe" showing green validation colors.
With this commit, after requests that return "salutation x" , the salutation field
is set to an empty status.

DEV-343/4: Until now, the salutation field was automatically set for an unlimited
number of requests.  This prevented users from selecting a neutral option (salutation x),
which is no longer in line with modern standards as it forces a gender disclosure.
In this commit, the code block that automatically sets the salutation field is moved
inside the clause controlled by the new nameCorrected flag. This ensures, that the
salutation will only be automatically set on time max.

DEV-343/5:  On requests with empty firstName or empty lastName, for example
"Herr Müller" or "Herr Florian", the API returns "name_correct" and the status
of both input fields is set to "correct". This resulted in an empty input field, showing
green validation colors.
This commit introduces a ternary operator, that ensures, that only the status of
not-empty firstName or lastName fields will be set to "correct".
