### PR TITLE
Fix focus can get lost on Tab on address fields

### DIFF
--- a/modules/extensions/fields/LocalityExtension.js
+++ b/modules/extensions/fields/LocalityExtension.js
@@ -287,18 +287,25 @@ const LocalityExtension = {
                     ExtendableObject.resetLocalityPredictions();
                     ExtendableObject.util.removeLocalityPredictionsDropdown();
                 } else if (e.key === 'Tab') {
-                    if (ExtendableObject._localityPredictions.length > 0 && ExtendableObject._localityPredictionsIndex >= 0) {
+                    if (ExtendableObject._localityPredictions.length > 0) {
                         e.preventDefault();
 
                         (async () => {
-                            await ExtendableObject.cb.applyLocalityPredictionSelection(
-                                ExtendableObject._localityPredictionsIndex,
-                                ExtendableObject._localityPredictions
-                            );
+                            const anythingSelected = ExtendableObject._localityPredictionsIndex >= 0;
+
+                            // Apply selection, if a suggestion was selected
+                            if (anythingSelected) {
+                                await ExtendableObject.cb.applyLocalityPredictionSelection(
+                                    ExtendableObject._localityPredictionsIndex,
+                                    ExtendableObject._localityPredictions
+                                );
+                            }
+
+                            // Always reset and close on "Tab"
                             ExtendableObject.resetLocalityPredictions();
                             ExtendableObject.util.removeLocalityPredictionsDropdown();
 
-                            // Find next focusable element
+                            // Always find next focusable element on "Tab"
                             const focusableElements = Array.from(document.querySelectorAll(
                                 'input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])'
                             ));

--- a/modules/extensions/fields/PostalCodeExtension.js
+++ b/modules/extensions/fields/PostalCodeExtension.js
@@ -290,18 +290,25 @@ const PostalCodeExtension = {
                     ExtendableObject.resetPostalCodePredictions();
                     ExtendableObject.util.removePostalCodePredictionsDropdown();
                 } else if (e.key === 'Tab') {
-                    if (ExtendableObject._postalCodePredictions.length > 0 && ExtendableObject._postalCodePredictionsIndex >= 0) {
+                    if (ExtendableObject._postalCodePredictions.length > 0) {
                         e.preventDefault();
 
                         (async () => {
-                            await ExtendableObject.cb.applyPostalCodePredictionSelection(
-                                ExtendableObject._postalCodePredictionsIndex,
-                                ExtendableObject._postalCodePredictions
-                            );
+                            const anythingSelected = ExtendableObject._postalCodePredictionsIndex >= 0;
+
+                            // Apply selection, if a suggestion was selected
+                            if (anythingSelected) {
+                                await ExtendableObject.cb.applyPostalCodePredictionSelection(
+                                    ExtendableObject._postalCodePredictionsIndex,
+                                    ExtendableObject._postalCodePredictions
+                                );
+                            }
+
+                            // Always reset and close on "Tab"
                             ExtendableObject.resetPostalCodePredictions();
                             ExtendableObject.util.removePostalCodePredictionsDropdown();
 
-                            // Find next focusable element
+                            // Always find next focusable element on "Tab"
                             const focusableElements = Array.from(document.querySelectorAll(
                                 'input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])'
                             ));

--- a/modules/extensions/fields/StreetFullExtension.js
+++ b/modules/extensions/fields/StreetFullExtension.js
@@ -285,18 +285,25 @@ const StreetFullExtension = {
                     ExtendableObject.resetStreetFullPredictions();
                     ExtendableObject.util.removeStreetFullPredictionsDropdown();
                 } else if (e.key === 'Tab') {
-                    if (ExtendableObject._streetFullPredictions.length > 0 && ExtendableObject._streetFullPredictionsIndex >= 0) {
+                    if (ExtendableObject._streetFullPredictions.length > 0) {
                         e.preventDefault();
 
                         (async () => {
-                            await ExtendableObject.cb.applyStreetFullPredictionSelection(
-                                ExtendableObject._streetFullPredictionsIndex,
-                                ExtendableObject._streetFullPredictions
-                            );
+                            const anythingSelected = ExtendableObject._streetFullPredictionsIndex >= 0;
+
+                            // Apply selection, if a suggestion was selected
+                            if (anythingSelected) {
+                                await ExtendableObject.cb.applyStreetFullPredictionSelection(
+                                    ExtendableObject._streetFullPredictionsIndex,
+                                    ExtendableObject._streetFullPredictions
+                                );
+                            }
+
+                            // Always reset and close on "Tab"
                             ExtendableObject.resetStreetFullPredictions();
                             ExtendableObject.util.removeStreetFullPredictionsDropdown();
 
-                            // Find next focusable element
+                            // Always find next focusable element on "Tab"
                             const focusableElements = Array.from(document.querySelectorAll(
                                 'input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])'
                             ));

--- a/modules/extensions/fields/StreetNameExtension.js
+++ b/modules/extensions/fields/StreetNameExtension.js
@@ -292,18 +292,25 @@ const StreetNameExtension = {
                     ExtendableObject.resetStreetNamePredictions();
                     ExtendableObject.util.removeStreetNamePredictionsDropdown();
                 } else if (e.key === 'Tab') {
-                    if (ExtendableObject._streetNamePredictions.length > 0 && ExtendableObject._streetNamePredictionsIndex >= 0) {
+                    if (ExtendableObject._streetNamePredictions.length > 0) {
                         e.preventDefault();
 
                         (async () => {
-                            await ExtendableObject.cb.applyStreetNamePredictionSelection(
-                                ExtendableObject._streetNamePredictionsIndex,
-                                ExtendableObject._streetNamePredictions
-                            );
+                            const anythingSelected = ExtendableObject._streetNamePredictionsIndex >= 0;
+
+                            // Apply selection, if a suggestion was selected
+                            if (anythingSelected) {
+                                await ExtendableObject.cb.applyStreetNamePredictionSelection(
+                                    ExtendableObject._streetNamePredictionsIndex,
+                                    ExtendableObject._streetNamePredictions
+                                );
+                            }
+
+                            // Always reset and close on "Tab"
                             ExtendableObject.resetStreetNamePredictions();
                             ExtendableObject.util.removeStreetNamePredictionsDropdown();
 
-                            // Find next focusable element
+                            // Always find next focusable element on "Tab"
                             const focusableElements = Array.from(document.querySelectorAll(
                                 'input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])'
                             ));


### PR DESCRIPTION
Pressing Tab on postalcode-, locality-, street- or streetFull input fields could cause the focus to get lost, when no suggestion was selected. This bug occured, when the predictions dropdown list was long enough to have a scroll bar,
with or without scroll thumb.
With no suggestion selected, the browser's default behaviour was not prevented. The browser tried to focus on the scrollbar, which was removed together with the predicitions list, causing the focus to get lost.

Changes:
For all cases in which a predicitions list is shown:
- Explicitly prevent the browser's default Tab behavior
- Programmatically close the predictions dropdown
- Manually manage the focus transition to the next element

REF: DEV-380

The changes where tested manually on postalcode-, locality-, street- and streetFull input fields.
For every field 6 cases where tested:
short/medium (scrollbar, no scroll thumb)/long (scrollbar with scroll thumb) predicitions list,
each tested with and without selecting a suggestion.