### PR TITLE
Ensure setting of name field status on requests with index > 1

### DIFF
--- a/modules/extensions/checks/NameCheckExtension.js
+++ b/modules/extensions/checks/NameCheckExtension.js
@@ -17,6 +17,7 @@ var NameCheckExtension = {
                 ExtendableObject._subscribers.titleStatus = [];
                 ExtendableObject._subscribers.nameScore = [];
                 ExtendableObject._nameCheckRequestIndex = 1;
+                ExtendableObject._nameCorrected = false;
 
                 // Add change event hadler.
                 ExtendableObject.cb.salutationStatusChange = function(subscriber) {
@@ -321,7 +322,7 @@ var NameCheckExtension = {
                                             salutationCopied = true;
                                         }
 
-                                        if (1 === ExtendableObject._nameCheckRequestIndex) {
+                                        if (!ExtendableObject._nameCorrected) {
                                             if (!responseStatus.includes('name_transpositioned')) {
                                                 ExtendableObject.firstName = responsePredictions[0].firstName;
                                                 ExtendableObject.lastName = responsePredictions[0].lastName;
@@ -359,6 +360,7 @@ var NameCheckExtension = {
                                                 ExtendableObject.firstNameStatus = ['first_name_correct'];
                                                 ExtendableObject.lastNameStatus = ['last_name_correct'];
                                             }
+                                            ExtendableObject._nameCorrected = true;
                                         }
 
                                         if (responseStatus.includes('name_correct')) {


### PR DESCRIPTION
When the first name check request returned "name_not_found", for example when there was a typo in the name, on the second request with API answer "name_needs_correction" the field status for firstName and lastName was not set. The reason was, that firstNameStatus and lastNameStatus where only set on the request with index 1.
This commit replaces the request index in the respective if-clause with a persistent boolean flag nameCorrected. This ensures, that firstNameStatus and lastNameStatus will be set on the first request that returns "name_needs_correction" and, as it was before, on every request that returns "name_correct".

The changes were tested and the desired behaviour was verified in the JS-SDK demo area. No regression was found.

Ref: DEV-462